### PR TITLE
Ya no se añade el paciente aunque su DNI sea incorrecto

### DIFF
--- a/test/create_patient.py
+++ b/test/create_patient.py
@@ -70,9 +70,9 @@ class Create_patient(QtWidgets.QMainWindow):
             QtWidgets.QMessageBox.critical(self, 'ERROR', "Introduce un DNI válido.")
         elif(self.dni_letters[int(self.dni.text()[:-1]) % 23] != self.dni.text()[-1]):
             QtWidgets.QMessageBox.critical(self, 'ERROR', "Letra del DNI errónea")
-        if(self.nom.text() == ""):
+        elif(self.nom.text() == ""):
             QtWidgets.QMessageBox.critical(self, 'ERROR', "Es obligatorio introducir un nombre.")
-        if(not self.check_mail):
+        elif(not self.check_mail):
             QtWidgets.QMessageBox.critical(self, 'ERROR', "El e-mail no és correcto.")
         else:
             try:


### PR DESCRIPTION
En principio con esto está solucionado el error, además tampoco saltara en caso de que el nombre o el email sean incorrectos